### PR TITLE
feat: add IAM managed policy for accessing S3 bucket and DynamoDB table

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -14,3 +14,7 @@
 ## DynamoDB Table
 
 - [[DynamoDB.2] DynamoDB tables should have point-in-time recovery enabled](https://docs.aws.amazon.com/securityhub/latest/userguide/dynamodb-controls.html#dynamodb-2)
+
+## IAM
+
+- Managed policy for accessing the S3 bucket and keys as well as the DynamoDB table.


### PR DESCRIPTION
- Added a new IAM managed policy to allow reading/writing to the S3 bucket and objects, as well as reading/writing to the DynamoDB table.
- The policy statements include actions such as `s3:ListBucket`, `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `dynamodb:DescribeTable`, `dynamodb:GetItem`, `dynamodb:PutItem`, and `dynamodb:DeleteItem`.
- The managed policy is named "TerraformStateBackendPolicy" and is associated with the Terraform state backend construct.

Fixes #